### PR TITLE
Create GitHub Actions for auto-build and release publishing

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -1,0 +1,28 @@
+name: Gradle Build on PR
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      
+    - name: Build with Gradle
+      run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release on PR Approval
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  build-and-release:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Build the project
+        run: ./gradlew build
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ github.run_number }}
+          release_name: Release ${{ github.run_number }}
+          draft: false
+          prerelease: false
+
+      - name: Upload JAR to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: build/libs/app.jar
+          asset_name: app.jar
+          asset_content_type: application/java-archive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release on PR Approval
 
 on:
-  pull_request_review:
-    types: [submitted]
+  push:
+    branches: [ main ]
 
 jobs:
   build-and-release:


### PR DESCRIPTION
# Summary

## Problem
To prevent code from being sent to PR without `./gradlew build` being run, we can use a GitHub Action. We also need a way to create a `.jar` file of our project each time we add new code.


## Solution
- Created `gradle-build.yml` and `release.yml` files in the `.github/workflows` directory

### Ready for merging?

Yes

## Related Tickets
- https://github.com/users/AndGitRepos/projects/4?pane=issue&itemId=101552048


# Revisions

## Revision 1

Initial revision.

# Testing
N/A
