### PR TITLE
Fix Gradle test action

### DIFF
--- a/.github/workflows/gradle-test.yml
+++ b/.github/workflows/gradle-test.yml
@@ -1,10 +1,8 @@
 name: Gradle Test on PR
 
 on:
-  workflow_run:
-    workflows: [ "Gradle Build on PR" ]
-    types:
-      - completed
+  pull_request:
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
# Summary

## Problem

The GitHub action to run `./gradlew test` is not showing in the checks logs in the PR screen

## Solution

- Changed the trigger in the workflow

### Ready for merging?

Yes

## Related Tickets

[Investigate and Implement CI/CD pipeline options within GitHub
](https://github.com/users/AndGitRepos/projects/9/views/1?pane=issue&itemId=103517576&issue=AndGitRepos%7CStudentManagerSystem%7C23)

# Revisions

## Revision 1

Initial revision.

# Testing

Not required for GitHub Actions