### PR TITLE
Fix build-jars.yml

### DIFF
--- a/.github/workflows/build-jars.yml
+++ b/.github/workflows/build-jars.yml
@@ -49,7 +49,8 @@ jobs:
           done
 
       - name: Upload JAR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jar-${{ matrix.platform }}
           path: app/build/libs/*-${{ matrix.platform }}.jar
+          retention-days: 1


### PR DESCRIPTION
# Summary

## Problem

Build-jars workflow is failing at the last artifact stage

## Solution

- Update version of artifact to v4
- Add retention day

### Ready for merging?

Yes

## Related Tickets

N/A

# Revisions

## Revision 1

Initial revision.

# Testing

N/A