### PR TITLE
Fix create-scripts.yml and create-release.yml

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,15 +16,17 @@ jobs:
 
     steps:
       - name: Download JARs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
+          retention-days: 1
 
       - name: Download Scripts and Docs
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: scripts-and-docs
           path: release-files
+          retention-days: 1
 
       - name: Get Latest Release Number
         id: get_latest_release

--- a/.github/workflows/create-scripts.yml
+++ b/.github/workflows/create-scripts.yml
@@ -71,10 +71,11 @@ jobs:
           4. Make sure you are using the JAR built for your platform' > README.md
 
       - name: Upload Scripts and Docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: scripts-and-docs
           path: |
             run.sh
             run.bat
             README.md
+          retention-days: 1


### PR DESCRIPTION
# Summary

## Problem

Create-scripts and create-release workflows failing due to artifact version

## Solution

- Change artifact version to 4

### Ready for merging?

Yes

## Related Tickets

N/A

# Revisions

## Revision 1

Initial revision.

# Testing

`./gradlew build` Unit tests pass