### PR TITLE
Add Assessment and AssessmentDAO with unit tests

### DIFF
--- a/app/src/main/java/sms/gradle/model/dao/AssessmentDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/AssessmentDAO.java
@@ -1,3 +1,203 @@
 package sms.gradle.model.dao;
 
-public class AssessmentDAO {}
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import sms.gradle.model.entities.Assessment;
+
+public final class AssessmentDAO {
+    private AssessmentDAO() {
+        throw new UnsupportedOperationException("This is a DAO class and cannot be instantiated");
+    }
+
+    /**
+     * Converts a <code>ResultSet</code> containing assessment data into a List of <code>Assessment</code> objects
+     * @param resultSet The ResultSet containing assessment data to convert
+     * @return A List of Assessment objects created from the ResultSet data
+     * @throws SQLException if there is an error accessing the ResultSet data
+     */
+    private static List<Assessment> getAllAssessmentsFromResultSet(final ResultSet resultSet) throws SQLException {
+        List<Assessment> assessments = new ArrayList<>();
+        while (resultSet.next()) {
+            assessments.add(new Assessment(
+                    resultSet.getInt("id"),
+                    resultSet.getString("name"),
+                    resultSet.getString("description"),
+                    resultSet.getDate("due_date"),
+                    resultSet.getInt("module_id")));
+        }
+        return assessments;
+    }
+
+    /**
+     * Converts a <code>ResultSet</code> containing assessment data into a single <code>Optional<Assessment></code> object
+     * @param resultSet The ResultSet containing assessment data to convert
+     * @return An Optional containing the Assessment object if data is found, or an empty Optional if not data is found
+     * @throws SQLException if there is an error accessing the ResultSet data
+     */
+    private static Optional<Assessment> getAssessmentFromResultSet(final ResultSet resultSet) throws SQLException {
+        if (resultSet.next()) {
+            return Optional.of(new Assessment(
+                    resultSet.getInt("id"),
+                    resultSet.getString("name"),
+                    resultSet.getString("description"),
+                    resultSet.getDate("due_date"),
+                    resultSet.getInt("module_id")));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Adds a new assessment to type database
+     * @param assessment The Assessment to add
+     * @throws SQLException if there is an error executing the query
+     */
+    public static void addAssessment(final Assessment assessment) throws SQLException {
+        final String sql = "INSERT INTO assessments (name, description, due_date, module_id) VALUES (?, ? , ?, ?)";
+        try (PreparedStatement addSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            addSqlStatement.setString(1, assessment.getName());
+            addSqlStatement.setString(2, assessment.getDescription());
+            addSqlStatement.setDate(3, assessment.getDueDate());
+            addSqlStatement.setInt(4, assessment.getModuleId());
+            addSqlStatement.executeUpdate();
+
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to add assessment: %s", assessment.toString()), e);
+        }
+    }
+
+    /**
+     * Finds an assessment by its ID
+     * @param id The ID of the assessment to find
+     * @return An Optional containing the Assessment Object if found, or an empty Optional if not found
+     * @throws SQLException if there is an error executing the query
+     */
+    public static Optional<Assessment> findById(final int id) throws SQLException {
+        final String sql = "SELECT * FROM assessment WHERE id = ?";
+        Optional<Assessment> assessment = Optional.empty();
+        try (PreparedStatement findSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            findSqlStatement.setInt(1, id);
+            ResultSet resultSet = findSqlStatement.executeQuery();
+            return getAssessmentFromResultSet(resultSet);
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to find assessment with Id: %d", id), e);
+        }
+    }
+
+    /**
+     * Finds an assessment by its name
+     * @param name The name of the assessment to find
+     * @return An Optional containing the Assessment object if found, or an empty Optional if not found
+     * @throws SQLException if there is an error executing the query
+     */
+    public static Optional<Assessment> findByName(final String name) throws SQLException {
+        final String sql = "SELECT * FROM assessments WHERE name = ?";
+        Optional<Assessment> assessment = Optional.empty();
+        try (PreparedStatement findSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            findSqlStatement.setString(1, name);
+            ResultSet resultSet = findSqlStatement.executeQuery();
+            return getAssessmentFromResultSet(resultSet);
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to find assessment with name: %s", name), e);
+        }
+    }
+
+    /**
+     * Find an assessment by its due date
+     * @param dueDate The due date for the assessment to find
+     * @return An Optional containing the Assessment object if found, or an empty Optional if not found
+     * @throws SQLException if there is an error executing the query
+     */
+    public static Optional<Assessment> findByDueDate(final Date dueDate) throws SQLException {
+        final String sql = "SELECT * FROM assessments WHERE due date = ?";
+        Optional<Assessment> assessment = Optional.empty();
+        try (PreparedStatement findSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            findSqlStatement.setDate(1, dueDate);
+            ResultSet resultSet = findSqlStatement.executeQuery();
+            return getAssessmentFromResultSet(resultSet);
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to find assessment with due date: %s", dueDate), e);
+        }
+    }
+
+    /**
+     * Finds an assessment by its module ID
+     * @param moduleId The module ID of the assessment to find
+     * @return An optional containing the Assessment object if found, or an empty Optional if not found
+     * @throws SQLException if there is an error executing the query
+     */
+    public static Optional<Assessment> findByModuleId(final int moduleId) throws SQLException {
+        final String sql = "SELECT * FROM modules WHERE module_id = ?";
+        Optional<Assessment> assessment = Optional.empty();
+        try (PreparedStatement findSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            findSqlStatement.setInt(1, moduleId);
+            ResultSet resultSet = findSqlStatement.executeQuery();
+            return getAssessmentFromResultSet(resultSet);
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to find all assessments with module_Id: %d", moduleId), e);
+        }
+    }
+    /**
+     * Finds all the assessments within the Database table
+     * @return A List containing all Assessment objects in the database
+     * @throws SQLException if there is an error executing the query
+     */
+    public static List<Assessment> findAll() throws SQLException {
+        final String sql = "SELECT * FROM assessments";
+        try (PreparedStatement findSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            ResultSet resultSet = findSqlStatement.executeQuery();
+            return getAllAssessmentsFromResultSet(resultSet);
+        } catch (SQLException e) {
+            throw new SQLException("Failed to find all assessments", e);
+        }
+    }
+
+    /**
+     * Updates an assessment in the database
+     * @param assessment The Assessment object with updated information
+     * @return The number of rows affected (1 if successful, 0 if module not found)
+     * @throws SQLException if there is an error executing the update operation
+     */
+    public static int update(final Assessment assessment) throws SQLException {
+        final String sql =
+                "UPDATE assessments SET name = ?, description = ?, due_date = ?, module_id = ?, WHERE id = ?";
+        try (PreparedStatement updateSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            updateSqlStatement.setString(1, assessment.getName());
+            updateSqlStatement.setString(2, assessment.getDescription());
+            updateSqlStatement.setDate(3, assessment.getDueDate());
+            updateSqlStatement.setInt(4, assessment.getModuleId());
+            updateSqlStatement.setInt(5, assessment.getId());
+            return updateSqlStatement.executeUpdate();
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to update assessment with Id: %d", assessment.getId()), e);
+        }
+    }
+
+    /**
+     * Deletes an assessment from the database by its ID
+     * @param id The ID of the assessment to delete
+     * @return The number of rows affected (1 if successful, 0 if module not found)
+     * @throws SQLException if there is an error executing the delete operation
+     */
+    public static int delete(final int id) throws SQLException {
+        final String sql = "DELETE FROM assessments WHERE id = ?";
+        try (PreparedStatement deleteSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            deleteSqlStatement.setInt(1, id);
+            return deleteSqlStatement.executeUpdate();
+        } catch (SQLException e) {
+            throw new SQLException(String.format("Failed to delete module Id: %d", id), e);
+        }
+    }
+}

--- a/app/src/main/java/sms/gradle/model/dao/AssessmentDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/AssessmentDAO.java
@@ -78,7 +78,7 @@ public final class AssessmentDAO {
      * @throws SQLException if there is an error executing the query
      */
     public static Optional<Assessment> findById(final int id) throws SQLException {
-        final String sql = "SELECT * FROM assessment WHERE id = ?";
+        final String sql = "SELECT * FROM assessments WHERE id = ?";
         Optional<Assessment> assessment = Optional.empty();
         try (PreparedStatement findSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
@@ -110,42 +110,41 @@ public final class AssessmentDAO {
     }
 
     /**
-     * Find an assessment by its due date
-     * @param dueDate The due date for the assessment to find
-     * @return An Optional containing the Assessment object if found, or an empty Optional if not found
+     * Find assessments by their due date
+     * @param dueDate The due date for the assessments to find
+     * @return A List containing all Assessment objects with matching due date in the Database table
      * @throws SQLException if there is an error executing the query
      */
-    public static Optional<Assessment> findByDueDate(final Date dueDate) throws SQLException {
-        final String sql = "SELECT * FROM assessments WHERE due date = ?";
-        Optional<Assessment> assessment = Optional.empty();
+    public static List<Assessment> findByDueDate(final Date dueDate) throws SQLException {
+        final String sql = "SELECT * FROM assessments WHERE due_date = ?";
         try (PreparedStatement findSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
             findSqlStatement.setDate(1, dueDate);
             ResultSet resultSet = findSqlStatement.executeQuery();
-            return getAssessmentFromResultSet(resultSet);
+            return getAllAssessmentsFromResultSet(resultSet);
         } catch (SQLException e) {
             throw new SQLException(String.format("Failed to find assessment with due date: %s", dueDate), e);
         }
     }
 
     /**
-     * Finds an assessment by its module ID
+     * Finds assessments by their module ID
      * @param moduleId The module ID of the assessment to find
-     * @return An optional containing the Assessment object if found, or an empty Optional if not found
+     * @return A List containing all Assessment objects with matching module ID in the Database table
      * @throws SQLException if there is an error executing the query
      */
-    public static Optional<Assessment> findByModuleId(final int moduleId) throws SQLException {
-        final String sql = "SELECT * FROM modules WHERE module_id = ?";
-        Optional<Assessment> assessment = Optional.empty();
+    public static List<Assessment> findByModuleId(final int moduleId) throws SQLException {
+        final String sql = "SELECT * FROM assessments WHERE module_id = ?";
         try (PreparedStatement findSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
             findSqlStatement.setInt(1, moduleId);
             ResultSet resultSet = findSqlStatement.executeQuery();
-            return getAssessmentFromResultSet(resultSet);
+            return getAllAssessmentsFromResultSet(resultSet);
         } catch (SQLException e) {
-            throw new SQLException(String.format("Failed to find all assessments with module_Id: %d", moduleId), e);
+            throw new SQLException(String.format("Failed to find all assessments with module ID: %d", moduleId), e);
         }
     }
+
     /**
      * Finds all the assessments within the Database table
      * @return A List containing all Assessment objects in the database
@@ -169,8 +168,7 @@ public final class AssessmentDAO {
      * @throws SQLException if there is an error executing the update operation
      */
     public static int update(final Assessment assessment) throws SQLException {
-        final String sql =
-                "UPDATE assessments SET name = ?, description = ?, due_date = ?, module_id = ?, WHERE id = ?";
+        final String sql = "UPDATE assessments SET name = ?, description = ?, due_date = ?, module_id = ? WHERE id = ?";
         try (PreparedStatement updateSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
             updateSqlStatement.setString(1, assessment.getName());

--- a/app/src/main/java/sms/gradle/model/entities/Assessment.java
+++ b/app/src/main/java/sms/gradle/model/entities/Assessment.java
@@ -1,3 +1,15 @@
 package sms.gradle.model.entities;
 
-public class Assessment {}
+import java.sql.Date;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Assessment {
+    private int id;
+    private String name;
+    private String description;
+    private Date dueDate;
+    private int moduleId;
+}

--- a/app/src/test/java/sms/gradle/model/dao/AssessmentDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/AssessmentDAOTest.java
@@ -38,7 +38,7 @@ public class AssessmentDAOTest {
     @Mock
     private ResultSet mockResultSet;
 
-    private final Date dueDate = java.sql.Date.valueOf("2025-10-10");
+    private final Date dueDate = java.sql.Date.valueOf("2025-10-30");
 
     @BeforeEach
     public void setUp() {
@@ -129,32 +129,47 @@ public class AssessmentDAOTest {
 
     @Test
     public void testFindByDueDate() throws SQLException {
-        Date dueDate = this.dueDate;
         when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
         when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.next()).thenReturn(true, false);
         when(mockResultSet.getInt("id")).thenReturn(1);
-        when(mockResultSet.getString("name")).thenReturn("Test Module");
+        when(mockResultSet.getString("name")).thenReturn("Test Assessment");
         when(mockResultSet.getString("description")).thenReturn("Test Description");
         when(mockResultSet.getDate("due_date")).thenReturn(dueDate);
         when(mockResultSet.getInt("module_id")).thenReturn(2);
 
-        Optional<Assessment> result = AssessmentDAO.findByDueDate(dueDate);
+        List<Assessment> result = AssessmentDAO.findByDueDate(dueDate);
 
         verify(mockPreparedStatement).setDate(1, dueDate);
-        verify(mockResultSet).next();
+        verify(mockResultSet, times(2)).next(); // Verify we checked for more results
         verify(mockResultSet).getInt("id");
         verify(mockResultSet).getString("name");
         verify(mockResultSet).getString("description");
         verify(mockResultSet).getDate("due_date");
         verify(mockResultSet).getInt("module_id");
 
-        assertTrue(result.isPresent());
-        assertEquals(1, result.get().getId());
-        assertEquals("Test Module", result.get().getName());
-        assertEquals("Test Description", result.get().getDescription());
-        assertEquals(dueDate, result.get().getDueDate());
-        assertEquals(2, result.get().getModuleId());
+        Assessment assessment = result.get(0);
+
+        assertEquals(1, result.size());
+        assertEquals(1, assessment.getId());
+        assertEquals("Test Assessment", assessment.getName());
+        assertEquals("Test Description", assessment.getDescription());
+        assertEquals(dueDate, assessment.getDueDate());
+        assertEquals(2, assessment.getModuleId());
+    }
+
+    @Test
+    public void testFindByDueDateNoResults() throws SQLException {
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        List<Assessment> result = AssessmentDAO.findByDueDate(dueDate);
+
+        verify(mockPreparedStatement).setDate(1, dueDate);
+        verify(mockResultSet).next();
+
+        assertTrue(result.isEmpty());
     }
 
     @Test
@@ -162,29 +177,46 @@ public class AssessmentDAOTest {
         int moduleId = 2;
         when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
         when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
-        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.next()).thenReturn(true, false);
         when(mockResultSet.getInt("id")).thenReturn(1);
         when(mockResultSet.getString("name")).thenReturn("Test Assessment");
         when(mockResultSet.getString("description")).thenReturn("Test Description");
         when(mockResultSet.getDate("due_date")).thenReturn(dueDate);
-        when(mockResultSet.getInt("module_id")).thenReturn(moduleId);
+        when(mockResultSet.getInt("module_id")).thenReturn(2);
 
-        Optional<Assessment> result = AssessmentDAO.findByModuleId(moduleId);
+        List<Assessment> result = AssessmentDAO.findByModuleId(moduleId);
 
         verify(mockPreparedStatement).setInt(1, moduleId);
-        verify(mockResultSet).next();
+        verify(mockResultSet, times(2)).next();
         verify(mockResultSet).getInt("id");
         verify(mockResultSet).getString("name");
         verify(mockResultSet).getString("description");
         verify(mockResultSet).getDate("due_date");
         verify(mockResultSet).getInt("module_id");
 
-        assertTrue(result.isPresent());
-        assertEquals(1, result.get().getId());
-        assertEquals("Test Assessment", result.get().getName());
-        assertEquals("Test Description", result.get().getDescription());
-        assertEquals(dueDate, result.get().getDueDate());
-        assertEquals(moduleId, result.get().getModuleId());
+        Assessment assessment = result.get(0);
+
+        assertEquals(1, result.size());
+        assertEquals(1, assessment.getId());
+        assertEquals("Test Assessment", assessment.getName());
+        assertEquals("Test Description", assessment.getDescription());
+        assertEquals(dueDate, assessment.getDueDate());
+        assertEquals(2, assessment.getModuleId());
+    }
+
+    @Test
+    public void testFindByModuleIdNoResults() throws SQLException {
+        int moduleId = 2;
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        List<Assessment> result = AssessmentDAO.findByModuleId(moduleId);
+
+        verify(mockPreparedStatement).setInt(1, moduleId);
+        verify(mockResultSet).next();
+
+        assertTrue(result.isEmpty());
     }
 
     @Test

--- a/app/src/test/java/sms/gradle/model/dao/AssessmentDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/AssessmentDAOTest.java
@@ -1,3 +1,254 @@
 package sms.gradle.model.dao;
 
-public class AssessmentDAOTest {}
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import sms.gradle.model.entities.Assessment;
+
+public class AssessmentDAOTest {
+    @Mock
+    private DatabaseConnection mockDbConnection;
+
+    private MockedStatic<DatabaseConnection> mockedStatic;
+
+    @Mock
+    private Connection mockConnection;
+
+    @Mock
+    private PreparedStatement mockPreparedStatement;
+
+    @Mock
+    private ResultSet mockResultSet;
+
+    private final Date dueDate = java.sql.Date.valueOf("2025-10-10");
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        mockedStatic = mockStatic(DatabaseConnection.class);
+        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        when(mockDbConnection.getConnection()).thenReturn(mockConnection);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        mockedStatic.close();
+    }
+
+    @Test
+    public void testAddAssessment() throws SQLException {
+        Assessment assessment = new Assessment(1, "Test Assessment", "Test Description", dueDate, 2);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeUpdate()).thenReturn(1);
+
+        AssessmentDAO.addAssessment(assessment);
+
+        verify(mockPreparedStatement).setString(1, assessment.getName());
+        verify(mockPreparedStatement).setString(2, assessment.getDescription());
+        verify(mockPreparedStatement).setDate(3, assessment.getDueDate());
+        verify(mockPreparedStatement).setInt(4, assessment.getModuleId());
+    }
+
+    @Test
+    public void testFindById() throws SQLException {
+        int assessmentId = 1;
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.getInt("id")).thenReturn(assessmentId);
+        when(mockResultSet.getString("name")).thenReturn("Test Assessment");
+        when(mockResultSet.getString("description")).thenReturn("Test Description");
+        when(mockResultSet.getDate("due_date")).thenReturn(dueDate);
+        when(mockResultSet.getInt("module_id")).thenReturn(2);
+
+        Optional<Assessment> result = AssessmentDAO.findById(assessmentId);
+
+        verify(mockPreparedStatement).setInt(1, assessmentId);
+        verify(mockResultSet).next();
+        verify(mockResultSet).getInt("id");
+        verify(mockResultSet).getString("name");
+        verify(mockResultSet).getString("description");
+        verify(mockResultSet).getDate("due_date");
+        verify(mockResultSet).getInt("module_id");
+
+        assertTrue(result.isPresent());
+        assertEquals(assessmentId, result.get().getId());
+        assertEquals("Test Assessment", result.get().getName());
+        assertEquals("Test Description", result.get().getDescription());
+        assertEquals(dueDate, result.get().getDueDate());
+        assertEquals(2, result.get().getModuleId());
+    }
+
+    @Test
+    public void testFindByName() throws SQLException {
+        String assessmentName = "Test Assessment";
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.getInt("id")).thenReturn(1);
+        when(mockResultSet.getString("name")).thenReturn(assessmentName);
+        when(mockResultSet.getString("description")).thenReturn("Test Description");
+        when(mockResultSet.getDate("due_date")).thenReturn(dueDate);
+        when(mockResultSet.getInt("module_id")).thenReturn(2);
+
+        Optional<Assessment> result = AssessmentDAO.findByName(assessmentName);
+
+        verify(mockPreparedStatement).setString(1, assessmentName);
+        verify(mockResultSet).next();
+        verify(mockResultSet).getInt("id");
+        verify(mockResultSet).getString("name");
+        verify(mockResultSet).getString("description");
+        verify(mockResultSet).getDate("due_date");
+        verify(mockResultSet).getInt("module_id");
+
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().getId());
+        assertEquals(assessmentName, result.get().getName());
+        assertEquals("Test Description", result.get().getDescription());
+        assertEquals(dueDate, result.get().getDueDate());
+        assertEquals(2, result.get().getModuleId());
+    }
+
+    @Test
+    public void testFindByDueDate() throws SQLException {
+        Date dueDate = this.dueDate;
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.getInt("id")).thenReturn(1);
+        when(mockResultSet.getString("name")).thenReturn("Test Module");
+        when(mockResultSet.getString("description")).thenReturn("Test Description");
+        when(mockResultSet.getDate("due_date")).thenReturn(dueDate);
+        when(mockResultSet.getInt("module_id")).thenReturn(2);
+
+        Optional<Assessment> result = AssessmentDAO.findByDueDate(dueDate);
+
+        verify(mockPreparedStatement).setDate(1, dueDate);
+        verify(mockResultSet).next();
+        verify(mockResultSet).getInt("id");
+        verify(mockResultSet).getString("name");
+        verify(mockResultSet).getString("description");
+        verify(mockResultSet).getDate("due_date");
+        verify(mockResultSet).getInt("module_id");
+
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().getId());
+        assertEquals("Test Module", result.get().getName());
+        assertEquals("Test Description", result.get().getDescription());
+        assertEquals(dueDate, result.get().getDueDate());
+        assertEquals(2, result.get().getModuleId());
+    }
+
+    @Test
+    public void testFindByModuleId() throws SQLException {
+        int moduleId = 2;
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.getInt("id")).thenReturn(1);
+        when(mockResultSet.getString("name")).thenReturn("Test Assessment");
+        when(mockResultSet.getString("description")).thenReturn("Test Description");
+        when(mockResultSet.getDate("due_date")).thenReturn(dueDate);
+        when(mockResultSet.getInt("module_id")).thenReturn(moduleId);
+
+        Optional<Assessment> result = AssessmentDAO.findByModuleId(moduleId);
+
+        verify(mockPreparedStatement).setInt(1, moduleId);
+        verify(mockResultSet).next();
+        verify(mockResultSet).getInt("id");
+        verify(mockResultSet).getString("name");
+        verify(mockResultSet).getString("description");
+        verify(mockResultSet).getDate("due_date");
+        verify(mockResultSet).getInt("module_id");
+
+        assertTrue(result.isPresent());
+        assertEquals(1, result.get().getId());
+        assertEquals("Test Assessment", result.get().getName());
+        assertEquals("Test Description", result.get().getDescription());
+        assertEquals(dueDate, result.get().getDueDate());
+        assertEquals(moduleId, result.get().getModuleId());
+    }
+
+    @Test
+    public void testFindAll() throws SQLException {
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true, true, false);
+        when(mockResultSet.getInt("id")).thenReturn(1, 2);
+        when(mockResultSet.getString("name")).thenReturn("Test Module One", "Test Module Two");
+        when(mockResultSet.getString("description")).thenReturn("Test Description One", "Test Description Two");
+        when(mockResultSet.getDate("due_date")).thenReturn(dueDate, dueDate);
+        when(mockResultSet.getInt("module_id")).thenReturn(2, 4);
+
+        List<Assessment> results = AssessmentDAO.findAll();
+
+        verify(mockPreparedStatement).executeQuery();
+        verify(mockResultSet, times(3)).next();
+        verify(mockResultSet, times(2)).getInt("id");
+        verify(mockResultSet, times(2)).getString("name");
+        verify(mockResultSet, times(2)).getString("description");
+        verify(mockResultSet, times(2)).getDate("due_date");
+        verify(mockResultSet, times(2)).getInt("module_id");
+
+        assertEquals(2, results.size());
+        assertEquals(1, results.get(0).getId());
+        assertEquals("Test Module One", results.get(0).getName());
+        assertEquals("Test Description One", results.get(0).getDescription());
+        assertEquals(dueDate, results.get(0).getDueDate());
+        assertEquals(2, results.get(0).getModuleId());
+
+        assertEquals(2, results.get(1).getId());
+        assertEquals("Test Module Two", results.get(1).getName());
+        assertEquals("Test Description Two", results.get(1).getDescription());
+        assertEquals(dueDate, results.get(1).getDueDate());
+        assertEquals(4, results.get(1).getModuleId());
+    }
+
+    @Test
+    public void testUpdate() throws SQLException {
+        Assessment assessment = new Assessment(1, "Test Assessment", "Test Description", dueDate, 2);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeUpdate()).thenReturn(1);
+
+        int result = AssessmentDAO.update(assessment);
+
+        verify(mockPreparedStatement).setString(1, assessment.getName());
+        verify(mockPreparedStatement).setString(2, assessment.getDescription());
+        verify(mockPreparedStatement).setDate(3, assessment.getDueDate());
+        verify(mockPreparedStatement).setInt(4, assessment.getModuleId());
+        verify(mockPreparedStatement).setInt(5, assessment.getId());
+
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void testDelete() throws SQLException {
+        int assessmentId = 1;
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeUpdate()).thenReturn(1);
+
+        int result = AssessmentDAO.delete(assessmentId);
+
+        verify(mockPreparedStatement).setInt(1, assessmentId);
+
+        assertEquals(1, result);
+    }
+}


### PR DESCRIPTION
# Summary

## Problem

Both Assessment and AssessmentDAO classes are not defined.
We need these defined to progress through implementing the Model.

## Solution

- Add Assessment
- Add AssessmentDAO
- Add unit tests for AssessmentDAO

### Ready for merging?

Yes

## Related Tickets

[Implement Assessment and AssessmentDAO classes](https://github.com/AndGitRepos/StudentManagerSystem/issues/16)

# Revisions

## Revision 2

- Changed optionals to lists for where there can be multiple results.
- Added tests for where lists can be empty.
- Minor fixes.

## Revision 1

Initial revision.

# Testing

`./gradlew build` Unit tests pass