### PR TITLE
Fix referential integrity within DAO classes

### DIFF
--- a/app/src/main/java/sms/gradle/controller/ManageStudentController.java
+++ b/app/src/main/java/sms/gradle/controller/ManageStudentController.java
@@ -9,7 +9,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import sms.gradle.model.dao.CourseDAO;
 import sms.gradle.model.dao.CourseEnrollmentDAO;
-import sms.gradle.model.dao.ResultDAO;
 import sms.gradle.model.dao.StudentDAO;
 import sms.gradle.model.entities.Course;
 import sms.gradle.model.entities.CourseEnrollment;
@@ -153,8 +152,6 @@ public final class ManageStudentController {
         if (selectedStudent != null) {
             LOGGER.debug("Deleting student: {}", selectedStudent);
             try {
-                ResultDAO.deleteByStudentId(selectedStudent.getId());
-                CourseEnrollmentDAO.deleteByStudentId(selectedStudent.getId());
                 StudentDAO.delete(selectedStudent.getId());
                 studentList.getItems().remove(selectedStudent);
             } catch (SQLException e) {

--- a/app/src/main/java/sms/gradle/model/dao/AdminDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/AdminDAO.java
@@ -165,6 +165,10 @@ public final class AdminDAO {
      */
     public static int delete(final int id) throws SQLException {
         LOGGER.debug("Deleting admin with ID: {}", id);
+        if (AdminDAO.getTableSize() == 1) {
+            throw new SQLException("Cannot delete the last admin");
+        }
+
         final String sql = "DELETE FROM admins WHERE id = ?";
         try (PreparedStatement deleteSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
@@ -199,6 +203,22 @@ public final class AdminDAO {
         } catch (SQLException e) {
             LOGGER.error("Failed to verify password for admin with email: {}", email, e);
             throw new SQLException(String.format("Failed to verify password for admin with email: %s", email), e);
+        }
+    }
+
+    public static int getTableSize() throws SQLException {
+        LOGGER.debug("Getting table size");
+        final String sql = "SELECT COUNT(*) FROM admins";
+        try (PreparedStatement findSqlStatement =
+                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
+            ResultSet results = findSqlStatement.executeQuery();
+            if (results.next()) {
+                return results.getInt(1);
+            }
+            return 0;
+        } catch (SQLException e) {
+            LOGGER.error("Failed to get table size", e);
+            throw new SQLException("Failed to get table size", e);
         }
     }
 }

--- a/app/src/main/java/sms/gradle/model/dao/AssessmentDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/AssessmentDAO.java
@@ -211,6 +211,7 @@ public final class AssessmentDAO {
      */
     public static int delete(final int id) throws SQLException {
         LOGGER.debug("Deleting assessment with ID: {}", id);
+        ResultDAO.deleteByAssessmentId(id);
         final String sql = "DELETE FROM assessments WHERE id = ?";
         try (PreparedStatement deleteSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
@@ -218,7 +219,17 @@ public final class AssessmentDAO {
             return deleteSqlStatement.executeUpdate();
         } catch (SQLException e) {
             LOGGER.error("Failed to delete assessment with ID: {}", id, e);
-            throw new SQLException(String.format("Failed to delete module Id: %d", id), e);
+            throw new SQLException(String.format("Failed to delete assessment with Id: %d", id), e);
         }
+    }
+
+    public static int deleteByModuleId(final int moduleId) throws SQLException {
+        LOGGER.debug("Deleting assessments by module ID: {}", moduleId);
+        List<Assessment> assessments = AssessmentDAO.findByModuleId(moduleId);
+        for (Assessment assessment : assessments) {
+            AssessmentDAO.delete(assessment.getId());
+        }
+        LOGGER.info("Deleted {} assessments for module ID: {}", assessments.size(), moduleId);
+        return assessments.size();
     }
 }

--- a/app/src/main/java/sms/gradle/model/dao/CourseDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/CourseDAO.java
@@ -156,6 +156,7 @@ public final class CourseDAO {
      */
     public static int delete(final int id) throws SQLException {
         LOGGER.debug("Deleting course with ID: {}", id);
+        ModuleDAO.deleteByCourseId(id);
         final String sql = "DELETE FROM courses WHERE id = ?";
         try (PreparedStatement deleteSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {

--- a/app/src/main/java/sms/gradle/model/dao/CourseEnrollmentDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/CourseEnrollmentDAO.java
@@ -209,16 +209,12 @@ public final class CourseEnrollmentDAO {
      */
     public static int deleteByStudentId(final int studentId) throws SQLException {
         LOGGER.debug("Deleting course enrollments for student with ID: {}", studentId);
-        final String sql = "DELETE FROM course_enrollments WHERE student_id = ?";
-        try (PreparedStatement deleteSqlStatement =
-                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
-            deleteSqlStatement.setInt(1, studentId);
-            return deleteSqlStatement.executeUpdate();
-        } catch (SQLException e) {
-            LOGGER.error("Failed to delete course enrollments for student with ID: {}", studentId, e);
-            throw new SQLException(
-                    String.format("Failed to delete course enrollments for student with Id: %d", studentId), e);
+        List<CourseEnrollment> courseEnrollments = findByStudentId(studentId);
+        for (CourseEnrollment courseEnrollment : courseEnrollments) {
+            delete(courseEnrollment.getId());
         }
+        LOGGER.info("Deleted {} course enrollments for student with ID: {}", courseEnrollments.size(), studentId);
+        return courseEnrollments.size();
     }
 
     /**
@@ -229,15 +225,11 @@ public final class CourseEnrollmentDAO {
      */
     public static int deleteByCourseId(final int courseId) throws SQLException {
         LOGGER.debug("Deleting course enrollments for course with ID: {}", courseId);
-        final String sql = "DELETE FROM course_enrollments WHERE course_id = ?";
-        try (PreparedStatement deleteSqlStatement =
-                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
-            deleteSqlStatement.setInt(1, courseId);
-            return deleteSqlStatement.executeUpdate();
-        } catch (SQLException e) {
-            LOGGER.error("Failed to delete course enrollments for course with ID: {}", courseId, e);
-            throw new SQLException(
-                    String.format("Failed to delete course enrollments for course with Id: %d", courseId), e);
+        List<CourseEnrollment> courseEnrollments = findByCourseId(courseId);
+        for (CourseEnrollment courseEnrollment : courseEnrollments) {
+            delete(courseEnrollment.getId());
         }
+        LOGGER.info("Deleted {} course enrollments for course with ID: {}", courseEnrollments.size(), courseId);
+        return courseEnrollments.size();
     }
 }

--- a/app/src/main/java/sms/gradle/model/dao/ModuleDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/ModuleDAO.java
@@ -210,6 +210,7 @@ public final class ModuleDAO {
      */
     public static int delete(final int id) throws SQLException {
         LOGGER.debug("Deleting module with ID: {}", id);
+        AssessmentDAO.deleteByModuleId(id);
         final String sql = "DELETE FROM modules WHERE id = ?";
         try (PreparedStatement deleteSqlStatement =
                 DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
@@ -219,5 +220,21 @@ public final class ModuleDAO {
             LOGGER.error("Failed to delete module with ID: {}", id, e);
             throw new SQLException(String.format("Failed to delete module with Id: %d", id), e);
         }
+    }
+
+    /**
+     * Deletes all modules associated with a course ID
+     * @param courseId The course ID of the modules to delete
+     * @return The number of modules deleted
+     * @throws SQLException if there is an error executing the delete operation
+     */
+    public static int deleteByCourseId(final int courseId) throws SQLException {
+        LOGGER.debug("Deleting all modules associated with course ID: {}", courseId);
+        List<Module> modules = findByCourseId(courseId);
+        for (Module module : modules) {
+            delete(module.getId());
+        }
+        LOGGER.info("Deleted {} modules associated with course ID: {}", modules.size(), courseId);
+        return modules.size();
     }
 }

--- a/app/src/main/java/sms/gradle/model/dao/ResultDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/ResultDAO.java
@@ -218,16 +218,13 @@ public class ResultDAO {
      * @throws SQLException if there is an error executing the delete operation
      */
     public static int deleteByStudentId(final int studentId) throws SQLException {
-        LOGGER.debug("Deleting results for student with ID: {}", studentId);
-        final String sql = "DELETE FROM results WHERE student_id = ?";
-        try (PreparedStatement deleteSqlStatement =
-                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
-            deleteSqlStatement.setInt(1, studentId);
-            return deleteSqlStatement.executeUpdate();
-        } catch (SQLException e) {
-            LOGGER.error("Failed to delete results for student with ID: {}", studentId, e);
-            throw new SQLException(String.format("Failed to delete results for student with Id: %d", studentId), e);
+        LOGGER.debug("Deleting results by student id: {}", studentId);
+        List<Result> results = findByStudentId(studentId);
+        for (Result result : results) {
+            delete(result.getId());
         }
+        LOGGER.info("Deleted {} results for student id: {}", results.size(), studentId);
+        return results.size();
     }
 
     /**
@@ -238,16 +235,12 @@ public class ResultDAO {
      * @throws SQLException if there is an error executing the delete operation
      */
     public static int deleteByAssessmentId(final int assessmentId) throws SQLException {
-        LOGGER.debug("Deleting results for assessment with ID: {}", assessmentId);
-        final String sql = "DELETE FROM results WHERE assessment_id = ?";
-        try (PreparedStatement deleteSqlStatement =
-                DatabaseConnection.getInstance().getConnection().prepareStatement(sql)) {
-            deleteSqlStatement.setInt(1, assessmentId);
-            return deleteSqlStatement.executeUpdate();
-        } catch (SQLException e) {
-            LOGGER.error("Failed to delete results for assessment with ID: {}", assessmentId, e);
-            throw new SQLException(
-                    String.format("Failed to delete results for assessment with Id: %d", assessmentId), e);
+        LOGGER.debug("Deleting results by assessment id: {}", assessmentId);
+        List<Result> results = findByAssessmentId(assessmentId);
+        for (Result result : results) {
+            delete(result.getId());
         }
+        LOGGER.info("Deleted {} results for assessment id: {}", results.size(), assessmentId);
+        return results.size();
     }
 }

--- a/app/src/main/java/sms/gradle/model/dao/StudentDAO.java
+++ b/app/src/main/java/sms/gradle/model/dao/StudentDAO.java
@@ -174,6 +174,8 @@ public final class StudentDAO {
      * @throws SQLException if there is an error executing the delete operation
      */
     public static int delete(final int id) throws SQLException {
+        ResultDAO.deleteByStudentId(id);
+        CourseEnrollmentDAO.deleteByStudentId(id);
         LOGGER.debug("Deleting student with ID: {}", id);
         final String sql = "DELETE FROM students WHERE id = ?";
         try (PreparedStatement deleteSqlStatement =
@@ -184,6 +186,22 @@ public final class StudentDAO {
             LOGGER.error("Failed to delete student with ID: {}", id, e);
             throw new SQLException(String.format("Failed to delete student with Id: %d", id), e);
         }
+    }
+
+    /**
+     * Deletes a student from the database by its email address
+     * @param email The email address of the student to delete
+     * @return The number of rows affected (1 if successful, 0 if student not found)
+     * @throws SQLException if there is an error executing the delete operation
+     */
+    public static int deleteByEmail(final String email) throws SQLException {
+        LOGGER.debug("Deleting student with email: {}", email);
+        Optional<Student> student = findByEmail(email);
+        if (student.isPresent()) {
+            return delete(student.get().getId());
+        }
+        LOGGER.info("No student found with email: {}", email);
+        return 0;
     }
 
     /**

--- a/app/src/test/java/sms/gradle/model/dao/AdminDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/AdminDAOTest.java
@@ -27,7 +27,7 @@ public class AdminDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
 
     @Mock
     private Connection mockConnection;
@@ -41,14 +41,14 @@ public class AdminDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
     }
 
     @Test
@@ -158,6 +158,11 @@ public class AdminDAOTest {
     @Test
     public void testDeleteAdmin() throws SQLException {
         int adminId = 1;
+        when(mockConnection.prepareStatement("SELECT COUNT(*) FROM admins")).thenReturn(mockPreparedStatement);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(true);
+        when(mockResultSet.getInt(1)).thenReturn(2);
+
         when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
         when(mockPreparedStatement.executeUpdate()).thenReturn(1);
 

--- a/app/src/test/java/sms/gradle/model/dao/AssessmentDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/AssessmentDAOTest.java
@@ -2,6 +2,7 @@ package sms.gradle.model.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -27,7 +28,9 @@ public class AssessmentDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
+
+    private MockedStatic<ResultDAO> mockResultDAO;
 
     @Mock
     private Connection mockConnection;
@@ -43,14 +46,18 @@ public class AssessmentDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
+
+        mockResultDAO = mockStatic(ResultDAO.class);
+        mockResultDAO.when(() -> ResultDAO.deleteByAssessmentId(anyInt())).thenReturn(1);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
+        mockResultDAO.close();
     }
 
     @Test

--- a/app/src/test/java/sms/gradle/model/dao/CourseDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/CourseDAOTest.java
@@ -23,7 +23,9 @@ public class CourseDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
+
+    private MockedStatic<ModuleDAO> mockModuleDAO;
 
     @Mock
     private Connection mockConnection;
@@ -37,14 +39,18 @@ public class CourseDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
+
+        mockModuleDAO = mockStatic(ModuleDAO.class);
+        mockModuleDAO.when(() -> ModuleDAO.deleteByCourseId(anyInt())).thenReturn(1);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
+        mockModuleDAO.close();
     }
 
     @Test

--- a/app/src/test/java/sms/gradle/model/dao/CourseEnrollmentDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/CourseEnrollmentDAOTest.java
@@ -20,7 +20,7 @@ public class CourseEnrollmentDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
 
     @Mock
     private Connection mockConnection;
@@ -34,14 +34,14 @@ public class CourseEnrollmentDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
     }
 
     @Test

--- a/app/src/test/java/sms/gradle/model/dao/ModuleDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/ModuleDAOTest.java
@@ -24,7 +24,9 @@ public class ModuleDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
+
+    private MockedStatic<AssessmentDAO> mockAssessmentDAO;
 
     @Mock
     private Connection mockConnection;
@@ -38,14 +40,18 @@ public class ModuleDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
+
+        mockAssessmentDAO = mockStatic(AssessmentDAO.class);
+        mockAssessmentDAO.when(() -> AssessmentDAO.deleteByModuleId(anyInt())).thenReturn(1);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
+        mockAssessmentDAO.close();
     }
 
     @Test

--- a/app/src/test/java/sms/gradle/model/dao/ResultDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/ResultDAOTest.java
@@ -23,7 +23,7 @@ public class ResultDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
 
     @Mock
     private Connection mockConnection;
@@ -37,14 +37,14 @@ public class ResultDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
     }
 
     @Test

--- a/app/src/test/java/sms/gradle/model/dao/StudentDAOTest.java
+++ b/app/src/test/java/sms/gradle/model/dao/StudentDAOTest.java
@@ -2,6 +2,7 @@ package sms.gradle.model.dao;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
@@ -28,7 +29,10 @@ public class StudentDAOTest {
     @Mock
     private DatabaseConnection mockDbConnection;
 
-    private MockedStatic<DatabaseConnection> mockedStatic;
+    private MockedStatic<DatabaseConnection> mockStaticDbConnection;
+
+    private MockedStatic<ResultDAO> mockResultDOA;
+    private MockedStatic<CourseEnrollmentDAO> mockCourseEnrollmentDAO;
 
     @Mock
     private Connection mockConnection;
@@ -42,14 +46,23 @@ public class StudentDAOTest {
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
-        mockedStatic = mockStatic(DatabaseConnection.class);
-        mockedStatic.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
+        mockStaticDbConnection = mockStatic(DatabaseConnection.class);
+        mockStaticDbConnection.when(DatabaseConnection::getInstance).thenReturn(mockDbConnection);
         when(mockDbConnection.getConnection()).thenReturn(mockConnection);
+
+        mockResultDOA = mockStatic(ResultDAO.class);
+        mockResultDOA.when(() -> ResultDAO.deleteByStudentId(anyInt())).thenReturn(1);
+        mockCourseEnrollmentDAO = mockStatic(CourseEnrollmentDAO.class);
+        mockCourseEnrollmentDAO
+                .when(() -> CourseEnrollmentDAO.deleteByStudentId(anyInt()))
+                .thenReturn(1);
     }
 
     @AfterEach
     public void tearDown() {
-        mockedStatic.close();
+        mockStaticDbConnection.close();
+        mockResultDOA.close();
+        mockCourseEnrollmentDAO.close();
     }
 
     @Test


### PR DESCRIPTION
# Summary

## Problem

Initially when we implemented the DAO classes, the `delete` methods only focus on deleting the record from their respective table. This causes referential integrity issues (e.g. Student record deleted from students table but still reference to that deleted records ID within another table).

## Solution

- Fix `delete` methods to call respective DAO classes to clear all references of a record
- Update DAO test classes by adding extra needed mocking
- Restrict AdminDAO class from deleting Admin record if only one exists

### Ready for merging?

Yes

## Related Tickets

[Fix database referential integrity when deleting records](https://github.com/users/AndGitRepos/projects/12/views/1?pane=issue&itemId=106538528&issue=AndGitRepos%7CStudentManagerSystem%7C98)

# Revisions

## Revision 1

Initial revision.

## Revision 2

Rebase and add missing logging

# Testing

`./gradlew build` Unit tests pass

