### PR TITLE
Implement Manage Assessments feature with controller, view, and styling updates

### DIFF
--- a/app/src/main/java/sms/gradle/controller/admin/AdminDashboardController.java
+++ b/app/src/main/java/sms/gradle/controller/admin/AdminDashboardController.java
@@ -15,7 +15,7 @@ public final class AdminDashboardController {
 
     public static void handleManageAssessmentsButton(ActionEvent event) {
         LOGGER.debug("Manage Assessments button clicked");
-        // TODO - Once Manage assessments page has been implemented add call to change to
+        ViewFactory.getInstance().changeToManageAssessmentsStage();
     }
 
     public static void handleManageModulesButton(ActionEvent event) {

--- a/app/src/main/java/sms/gradle/controller/admin/ManageAssessmentsController.java
+++ b/app/src/main/java/sms/gradle/controller/admin/ManageAssessmentsController.java
@@ -1,0 +1,223 @@
+package sms.gradle.controller.admin;
+
+import java.sql.Date;
+import java.sql.SQLException;
+import java.util.List;
+import javafx.event.ActionEvent;
+import javafx.scene.Node;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import sms.gradle.model.dao.AssessmentDAO;
+import sms.gradle.model.dao.CourseDAO;
+import sms.gradle.model.dao.ModuleDAO;
+import sms.gradle.model.entities.Assessment;
+import sms.gradle.model.entities.Module;
+import sms.gradle.utils.Common;
+import sms.gradle.view.ViewFactory;
+
+public class ManageAssessmentsController {
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    /**
+     * Updates the list of assessments with all the assessments in the database
+     * @param event The action event that triggered this method
+     */
+    public static void updateListOfAssessments(ActionEvent event) {
+        LOGGER.debug("Updating list of assessments");
+
+        ListView<Assessment> assessmentsList = getNode("#assessmentsListView");
+        assessmentsList.getItems().clear();
+        try {
+            AssessmentDAO.findAll()
+                    .forEach(assessment -> assessmentsList.getItems().add(assessment));
+        } catch (SQLException e) {
+            LOGGER.error("Failed to update list of students: ", e);
+        }
+    }
+
+    /**
+     * Populates form fields with selected assessment's information and updates module lists.
+     *
+     * @param event The action event that triggered this method
+     */
+    public static void selectAssessment(ActionEvent event) {
+        LOGGER.debug("Selecting assessment");
+
+        ListView<Assessment> assessmentsListView = getNode("#assessmentsListView");
+        Assessment selectedAssessment = assessmentsListView.getSelectionModel().getSelectedItem();
+        Module linkedModule;
+
+        if (selectedAssessment == null) {
+            LOGGER.debug("No assessment selected. Ignoring.");
+            return;
+        }
+
+        LOGGER.debug("Selected assessment: {}", selectedAssessment);
+
+        try {
+            linkedModule = ModuleDAO.findById(selectedAssessment.getModuleId()).get();
+        } catch (SQLException e) {
+            LOGGER.error("Failed to get linked module from currently selected assessment");
+            return;
+        }
+
+        updateAssessmentDetails(selectedAssessment);
+        updateLinkedModuleDetails(linkedModule);
+        updateUnlinkedModulesListView();
+    }
+
+    /**
+     * Creates a new assessment in the database with the provided information.
+     *
+     * @param event The action event that triggered this method
+     */
+    public static void createNewAssessment(ActionEvent event) {
+        LOGGER.debug("Creating new assessment");
+
+        TextField nameField = getNode("#nameField");
+        TextField descriptionField = getNode("#descriptionField");
+        DatePicker dueDatePicker = getNode("#dueDatePicker");
+
+        Assessment newAssessment = new Assessment(
+                0,
+                nameField.getText(),
+                descriptionField.getText(),
+                Date.valueOf(dueDatePicker.getValue()),
+                getModuleIdFromLinkedModule());
+
+        try {
+            AssessmentDAO.addAssessment(newAssessment);
+            LOGGER.debug("New assessment created: {}", newAssessment);
+        } catch (SQLException e) {
+            LOGGER.error("Failed to create new assessment: ", e);
+        }
+    }
+
+    /**
+     * Deletes the selected assessment from the database.
+     *
+     * @param event The action event that triggered this method
+     */
+    public static void deleteAssessment(ActionEvent event) {
+        LOGGER.debug("Deleting assessment");
+        ListView<Assessment> assessmentsListView = getNode("#assessmentsListView");
+        Assessment selectedAssessment = assessmentsListView.getSelectionModel().getSelectedItem();
+
+        if (selectedAssessment == null) {
+            LOGGER.debug("No assessment selected. Ignoring.");
+            return;
+        }
+
+        LOGGER.debug("Deleting assessment: {}", selectedAssessment);
+        try {
+            AssessmentDAO.delete(selectedAssessment.getId());
+            assessmentsListView.getItems().remove(selectedAssessment);
+        } catch (SQLException e) {
+            LOGGER.error("Failed to delete assessment: ", e);
+        }
+    }
+
+    public static void swapLinkedModule(ActionEvent event) {
+        LOGGER.debug("Swapping linked module");
+        ListView<Module> unlinkedModulesListView = getNode("#unlinkedModulesListView");
+        Module selectedModule = unlinkedModulesListView.getSelectionModel().getSelectedItem();
+
+        if (selectedModule == null) {
+            LOGGER.debug("No module selected. Ignoring.");
+            return;
+        }
+
+        LOGGER.debug("Selected module: {}", selectedModule);
+        updateLinkedModuleDetails(selectedModule);
+        updateUnlinkedModulesListView();
+    }
+
+    public static void updateAssessment(ActionEvent event) {
+        LOGGER.debug("Updating assessment");
+
+        TextField assessmentIdField = getNode("#assessmentIdField");
+        TextField nameField = getNode("#nameField");
+        TextField descriptionField = getNode("#descriptionField");
+        DatePicker dueDatePicker = getNode("#dueDatePicker");
+
+        Assessment updatedAssessment = new Assessment(
+                Integer.parseInt(assessmentIdField.getText()),
+                nameField.getText(),
+                descriptionField.getText(),
+                Date.valueOf(dueDatePicker.getValue()),
+                getModuleIdFromLinkedModule());
+
+        try {
+            AssessmentDAO.update(updatedAssessment);
+            updateListOfAssessments(null);
+            LOGGER.debug("Assessment updated: {}", updatedAssessment);
+        } catch (SQLException e) {
+            LOGGER.error("Failed to update assessment: ", e);
+        }
+    }
+
+    private static void updateAssessmentDetails(Assessment selectedAssessment) {
+        TextField assessmentIdField = getNode("#assessmentIdField");
+        TextField nameField = getNode("#nameField");
+        TextField descriptionField = getNode("#descriptionField");
+        DatePicker dueDatePicker = getNode("#dueDatePicker");
+
+        assessmentIdField.setText(String.valueOf(selectedAssessment.getId()));
+        nameField.setText(selectedAssessment.getName());
+        descriptionField.setText(selectedAssessment.getDescription());
+        dueDatePicker.setValue(selectedAssessment.getDueDate().toLocalDate());
+    }
+
+    private static void updateLinkedModuleDetails(Module linkedModule) {
+        LOGGER.debug("Updating linked module");
+        try {
+            Label linkedModuleNameLabel = getNode("#linkedModuleNameLabel");
+            Label linkedModuleIdLabel = getNode("#linkedModuleIdLabel");
+            Label linkedModuleDescriptionLabel = getNode("#linkedModuleDescriptionLabel");
+            Label linkedModuleLecturerLabel = getNode("#linkedModuleLecturerLabel");
+            Label linkedModuleCourseNameLabel = getNode("#linkedModuleCourseNameLabel");
+
+            linkedModuleNameLabel.setText(linkedModule.getName());
+            linkedModuleIdLabel.setText("(" + linkedModule.getId() + ")");
+            linkedModuleDescriptionLabel.setText(linkedModule.getDescription());
+            linkedModuleLecturerLabel.setText(linkedModule.getLecturer());
+            linkedModuleCourseNameLabel.setText(
+                    CourseDAO.findById(linkedModule.getCourseId()).get().getName());
+        } catch (SQLException e) {
+            LOGGER.error("Failed to update linked modules list: ", e);
+        }
+    }
+
+    private static void updateUnlinkedModulesListView() {
+        LOGGER.debug("Updating unlinked modules list");
+
+        ListView<Module> unlinkedModulesListView = getNode("#unlinkedModulesListView");
+        unlinkedModulesListView.getItems().clear();
+
+        try {
+            List<Module> allModules = ModuleDAO.findAll();
+            for (Module module : allModules) {
+                // Don't add the currently linked module to the list
+                if (module.getId() != getModuleIdFromLinkedModule()) {
+                    unlinkedModulesListView.getItems().add(module);
+                }
+            }
+        } catch (SQLException e) {
+            LOGGER.error("Failed to update unlinked modules list: ", e);
+        }
+    }
+
+    private static int getModuleIdFromLinkedModule() {
+        Label linkedModuleIdLabel = getNode("#linkedModuleIdLabel");
+        String labelText = linkedModuleIdLabel.getText();
+        return Integer.parseInt(labelText.substring(1, labelText.length() - 1));
+    }
+
+    private static <T extends Node> T getNode(String selector) {
+        return Common.getNode(ViewFactory.getInstance().getManageAssessmentsStage(), selector);
+    }
+}

--- a/app/src/main/java/sms/gradle/utils/Common.java
+++ b/app/src/main/java/sms/gradle/utils/Common.java
@@ -6,6 +6,9 @@ import java.security.SecureRandom;
 import java.sql.Date;
 import java.sql.SQLException;
 import java.util.List;
+import javafx.scene.Node;
+import javafx.scene.control.Label;
+import javafx.stage.Stage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import sms.gradle.model.dao.*;
@@ -101,5 +104,23 @@ public final class Common {
         LOGGER.debug("Populated results table");
 
         LOGGER.info("Finished populating tables");
+    }
+
+    public static Label createStyledLabel(String text, String style) {
+        Label label = new Label(text);
+        label.setStyle(style);
+        return label;
+    }
+
+    /**
+     * Gets a node from a stage using a CSS selector
+     * @param <T> The type of node to return
+     * @param stage The stage to search in
+     * @param selector The CSS selector to search for
+     * @return The node matching the selector
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends Node> T getNode(Stage stage, String selector) {
+        return (T) stage.getScene().lookup(selector);
     }
 }

--- a/app/src/main/java/sms/gradle/view/Frames/admin/ManageAssessmentsView.java
+++ b/app/src/main/java/sms/gradle/view/Frames/admin/ManageAssessmentsView.java
@@ -1,0 +1,327 @@
+package sms.gradle.view.Frames.admin;
+
+import static javafx.geometry.Pos.CENTER;
+
+import java.sql.SQLException;
+import javafx.geometry.Insets;
+import javafx.scene.control.Button;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import sms.gradle.controller.admin.ManageAssessmentsController;
+import sms.gradle.model.dao.CourseDAO;
+import sms.gradle.model.dao.ModuleDAO;
+import sms.gradle.model.entities.Assessment;
+import sms.gradle.model.entities.Course;
+import sms.gradle.utils.Common;
+import sms.gradle.view.CoreViewInterface;
+import sms.gradle.view.ViewFactory;
+
+public class ManageAssessmentsView extends BorderPane implements CoreViewInterface {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    // Left Panel Components
+    private final ListView<Assessment> assessmentsListView = new ListView<>();
+    private final Button refreshButton = new Button("Refresh");
+    private final Button selectButton = new Button("Select");
+    private final Button deleteButton = new Button("Delete");
+    private final VBox leftPanel = new VBox(10);
+
+    // Center Panel Components
+    private final GridPane assessmentDetailsPane = new GridPane();
+    private final TextField assessmentIdField = new TextField();
+    private final TextField nameField = new TextField();
+    private final TextField descriptionField = new TextField();
+    private final DatePicker dueDatePicker = new DatePicker();
+    private final Button createNewButton = new Button("Create New");
+    private final Button updateButton = new Button("Update");
+    private final VBox centerPanel = new VBox(10);
+
+    // Right Panel Components
+    private final VBox linkedModuleContainer = new VBox(10);
+    private final Label linkedModuleNameLabel = new Label();
+    private final Label linkedModuleIdLabel = new Label();
+    private final Label linkedModuleDescriptionLabel = new Label();
+    private final Label linkedModuleLecturerLabel = new Label();
+    private final Label linkedModuleCourseNameLabel = new Label();
+    private final ListView<sms.gradle.model.entities.Module> unlinkedModulesListView = new ListView<>();
+    private final Button swapButton = new Button("Swap");
+    private final Button backButton = new Button("Back");
+    private final VBox rightPanel = new VBox(10);
+
+    public ManageAssessmentsView() {
+        getStylesheets().add(getClass().getResource("/styles/manager.css").toExternalForm());
+        initialiseCoreUIComponents();
+        layoutCoreUIComponents();
+        styleCoreUIComponents();
+        setupEventHandlers();
+        LOGGER.debug("Manage Assessments View initialised");
+    }
+
+    @Override
+    public void initialiseCoreUIComponents() {
+        setComponentIds();
+    }
+
+    private void setComponentIds() {
+        assessmentsListView.setId("assessmentsListView");
+        refreshButton.setId("refreshButton");
+        selectButton.setId("selectButton");
+        deleteButton.setId("deleteButton");
+        assessmentIdField.setId("assessmentIdField");
+        nameField.setId("nameField");
+        descriptionField.setId("descriptionField");
+        dueDatePicker.setId("dueDatePicker");
+        createNewButton.setId("updateButton");
+        updateButton.setId("updateButton");
+        linkedModuleContainer.setId("linkedModuleContainer");
+        linkedModuleNameLabel.setId("linkedModuleNameLabel");
+        linkedModuleIdLabel.setId("linkedModuleIdLabel");
+        linkedModuleDescriptionLabel.setId("linkedModuleDescriptionLabel");
+        linkedModuleLecturerLabel.setId("linkedModuleLecturerLabel");
+        linkedModuleCourseNameLabel.setId("linkedModuleCourseNameLabel");
+        unlinkedModulesListView.setId("unlinkedModulesListView");
+        swapButton.setId("swapButton");
+        backButton.setId("backButton");
+    }
+
+    @Override
+    public void layoutCoreUIComponents() {
+        layoutLeftPanel();
+        layoutCenterPanel();
+        layoutRightPanel();
+    }
+
+    private void layoutLeftPanel() {
+        leftPanel
+                .getChildren()
+                .addAll(
+                        new HBox(10, new Label("Assessments"), refreshButton),
+                        assessmentsListView,
+                        new HBox(10, selectButton, deleteButton));
+        leftPanel.setPadding(new Insets(10));
+        setLeft(leftPanel);
+    }
+
+    private void layoutCenterPanel() {
+        assessmentDetailsPane.setHgap(10);
+        assessmentDetailsPane.setVgap(10);
+        assessmentDetailsPane.addRow(0, new Label("Assessment ID:"), assessmentIdField);
+        assessmentDetailsPane.addRow(1, new Label("Name:"), nameField);
+        assessmentDetailsPane.addRow(2, new Label("Description:"), descriptionField);
+        assessmentDetailsPane.addRow(3, new Label("Due Date:"), dueDatePicker);
+
+        HBox buttonBox = new HBox(10, createNewButton, updateButton);
+        buttonBox.setAlignment(CENTER);
+
+        centerPanel.getChildren().addAll(new Label("Assessment Details"), assessmentDetailsPane, buttonBox);
+        centerPanel.setPadding(new Insets(10));
+        setCenter(centerPanel);
+    }
+
+    private void layoutRightPanel() {
+        HBox topLine = new HBox(linkedModuleNameLabel, linkedModuleIdLabel);
+        topLine.setSpacing(5);
+
+        linkedModuleContainer
+                .getChildren()
+                .addAll(topLine, linkedModuleDescriptionLabel, linkedModuleLecturerLabel, linkedModuleCourseNameLabel);
+
+        VBox modulesBox = new VBox(
+                10,
+                new Label("Linked Module"),
+                linkedModuleContainer,
+                swapButton,
+                new Label("Unlinked Modules"),
+                unlinkedModulesListView);
+
+        HBox controlButtons = new HBox(10, backButton);
+        controlButtons.setAlignment(CENTER);
+
+        rightPanel.getChildren().addAll(modulesBox, controlButtons);
+        rightPanel.setPadding(new Insets(10));
+        setRight(rightPanel);
+    }
+
+    @Override
+    public void styleCoreUIComponents() {
+        applyBasicStyles();
+        setupAssessmentsListViewCellFactory();
+        setupUnlinkedModulesListViewCellFactory();
+    }
+
+    private void applyBasicStyles() {
+        // Main container
+        getStyleClass().add("manage-assessments-view");
+
+        // Style containers and set widths as percentages
+        leftPanel.getStyleClass().add("left-panel");
+        centerPanel.getStyleClass().add("center-panel");
+        rightPanel.getStyleClass().add("right-panel");
+
+        // Add width binding to maintain proportions
+        widthProperty().addListener((obs, oldVal, newVal) -> {
+            double width = newVal.doubleValue();
+            // Left panel (25%)
+            leftPanel.setPrefWidth(width * 0.25);
+            leftPanel.setMinWidth(width * 0.25);
+            leftPanel.setMaxWidth(width * 0.25);
+
+            // Center panel (50%)
+            centerPanel.setPrefWidth(width * 0.50);
+            centerPanel.setMinWidth(width * 0.50);
+            centerPanel.setMaxWidth(width * 0.50);
+
+            // Right panel (25%)
+            rightPanel.setPrefWidth(width * 0.25);
+            rightPanel.setMinWidth(width * 0.25);
+            rightPanel.setMaxWidth(width * 0.25);
+        });
+
+        // Other styles
+        assessmentsListView.getStyleClass().add("assessments-list");
+        unlinkedModulesListView.getStyleClass().add("modules-list");
+        assessmentDetailsPane.getStyleClass().add("details-pane");
+
+        applyLabelStyles();
+        applyButtonStyles();
+    }
+
+    private void applyLabelStyles() {
+        linkedModuleNameLabel.setStyle("-fx-font-weight: bold; -fx-font-size: 14px;");
+        linkedModuleIdLabel.setStyle("-fx-font-style: italic; -fx-text-fill: grey; -fx-font-size: 12px;");
+        linkedModuleDescriptionLabel.setStyle("-fx-font-size: 12px;");
+        linkedModuleLecturerLabel.setStyle("-fx-font-size: 11px; -fx-text-fill: #555;");
+        linkedModuleCourseNameLabel.setStyle("-fx-font-size: 11px; -fx-text-fill: #555;");
+    }
+
+    private void applyButtonStyles() {
+        refreshButton.getStyleClass().add("action-button");
+        selectButton.getStyleClass().add("action-button");
+        deleteButton.getStyleClass().add("action-button");
+        createNewButton.getStyleClass().add("action-button");
+        updateButton.getStyleClass().add("action-button");
+        swapButton.getStyleClass().add("action-button");
+        backButton.getStyleClass().add("navigate-button");
+    }
+
+    private void setupAssessmentsListViewCellFactory() {
+        assessmentsListView.setCellFactory(lv -> new AssessmentListCell());
+    }
+
+    private void setupUnlinkedModulesListViewCellFactory() {
+        unlinkedModulesListView.setCellFactory(lv -> new ModuleListCell());
+    }
+
+    private void setupEventHandlers() {
+        refreshButton.setOnAction(ManageAssessmentsController::updateListOfAssessments);
+        selectButton.setOnAction(ManageAssessmentsController::selectAssessment);
+        createNewButton.setOnAction(ManageAssessmentsController::createNewAssessment);
+        updateButton.setOnAction(ManageAssessmentsController::updateAssessment);
+        deleteButton.setOnAction(ManageAssessmentsController::deleteAssessment);
+        swapButton.setOnAction(ManageAssessmentsController::swapLinkedModule);
+        backButton.setOnAction(event -> ViewFactory.getInstance().changeToAdminDashboardStage());
+    }
+
+    private static class AssessmentListCell extends ListCell<Assessment> {
+        @Override
+        protected void updateItem(Assessment assessment, boolean empty) {
+            super.updateItem(assessment, empty);
+            if (empty || assessment == null) {
+                setText(null);
+                setGraphic(null);
+                return;
+            }
+            setGraphic(createAssessmentDisplay(assessment));
+        }
+
+        private VBox createAssessmentDisplay(Assessment assessment) {
+            // Get module name using DAO
+            String moduleName;
+            try {
+                moduleName = ModuleDAO.findById(assessment.getModuleId())
+                        .map(sms.gradle.model.entities.Module::getName)
+                        .orElse("Unknown Module");
+            } catch (SQLException e) {
+                moduleName = "Unknown Module";
+            }
+
+            Label nameLabel =
+                    Common.createStyledLabel(assessment.getName(), "-fx-font-weight: bold; -fx-font-size: 14px;");
+
+            Label idLabel = Common.createStyledLabel(
+                    "(" + assessment.getId() + ")",
+                    "-fx-font-style: italic; -fx-text-fill: grey; -fx-font-size: 12px;");
+
+            HBox topLine = new HBox(5, nameLabel, idLabel);
+
+            Label descLabel = Common.createStyledLabel(assessment.getDescription(), "-fx-font-size: 12px;");
+
+            Label dueDateLabel = Common.createStyledLabel(
+                    "Due: " + assessment.getDueDate(), "-fx-font-size: 11px; -fx-text-fill: #555;");
+
+            Label moduleLabel =
+                    Common.createStyledLabel("Module: " + moduleName, "-fx-font-size: 11px; -fx-text-fill: #555;");
+
+            VBox content = new VBox(2, topLine, descLabel, dueDateLabel, moduleLabel);
+            content.setPadding(new Insets(5));
+
+            return content;
+        }
+    }
+
+    private static class ModuleListCell extends ListCell<sms.gradle.model.entities.Module> {
+        @Override
+        protected void updateItem(sms.gradle.model.entities.Module module, boolean empty) {
+            super.updateItem(module, empty);
+
+            if (empty || module == null) {
+                setText(null);
+                setGraphic(null);
+                return;
+            }
+            setGraphic(createModuleDisplay(module));
+        }
+
+        private VBox createModuleDisplay(sms.gradle.model.entities.Module module) {
+            // Lookup course name
+            String courseName;
+            try {
+                courseName = CourseDAO.findById(module.getCourseId())
+                        .map(Course::getName)
+                        .orElse("Unknown Course");
+            } catch (SQLException e) {
+                courseName = "Unknown Course";
+            }
+
+            Label nameLabel = Common.createStyledLabel(module.getName(), "-fx-font-weight: bold; -fx-font-size: 14px;");
+
+            Label idLabel = Common.createStyledLabel(
+                    " (" + module.getId() + ")", "-fx-font-style: italic; -fx-text-fill: grey; -fx-font-size: 12px;");
+
+            HBox topLine = new HBox(5, nameLabel, idLabel);
+
+            Label descLabel = Common.createStyledLabel(module.getDescription(), "-fx-font-size: 12px;");
+
+            Label lecturerLabel = Common.createStyledLabel(
+                    "Lecturer: " + module.getLecturer(), "-fx-font-size: 11px; -fx-text-fill: #555;");
+
+            Label courseLabel =
+                    Common.createStyledLabel("Course: " + courseName, "-fx-font-size: 11px; -fx-text-fill: #555;");
+
+            VBox content = new VBox(2, topLine, descLabel, lecturerLabel, courseLabel);
+            content.setPadding(new Insets(5));
+
+            return content;
+        }
+    }
+}

--- a/app/src/main/java/sms/gradle/view/ViewFactory.java
+++ b/app/src/main/java/sms/gradle/view/ViewFactory.java
@@ -1,11 +1,14 @@
 package sms.gradle.view;
 
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import lombok.Getter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import sms.gradle.utils.session.Session;
+import sms.gradle.view.Frames.admin.ManageAssessmentsView;
 import sms.gradle.view.frames.LoginView;
 import sms.gradle.view.frames.admin.AdminDashboardView;
 import sms.gradle.view.frames.admin.CourseDetailView;
@@ -34,6 +37,7 @@ public class ViewFactory {
     private Stage manageAdminStage;
     private Stage courseDetailStage;
     private Stage studentModulesStage;
+    private Stage manageAssessmentsStage;
 
     private ViewFactory() {
         LOGGER.info("Initialising View Factory");
@@ -46,6 +50,7 @@ public class ViewFactory {
         initialiseManageAdminStage();
         initialiseCourseDetailStage();
         initialiseStudentModulesStage();
+        initialiseManageAssessmentsStage();
         LOGGER.info("View Factory initialised");
     }
 
@@ -83,6 +88,7 @@ public class ViewFactory {
         manageCourseStage.hide();
         manageModulesStage.hide();
         manageAdminStage.hide();
+        manageAssessmentsStage.hide();
         courseDetailStage.hide();
         adminDashboardStage.show();
     }
@@ -115,6 +121,12 @@ public class ViewFactory {
         LOGGER.debug("Changing to course detail stage");
         adminDashboardStage.hide();
         courseDetailStage.show();
+    }
+
+    public void changeToManageAssessmentsStage() {
+        LOGGER.debug("Changing to manage assessments stage");
+        adminDashboardStage.hide();
+        manageAssessmentsStage.show();
     }
 
     private void initialiseLoginStage() {
@@ -218,5 +230,20 @@ public class ViewFactory {
         courseDetailStage.setMinWidth(750);
         courseDetailStage.setScene(new Scene(courseDetailView));
         courseDetailStage.setTitle("SMS - Course Detail");
+    }
+
+    private void initialiseManageAssessmentsStage() {
+        LOGGER.debug("Initialising manage assessments stage");
+
+        ManageAssessmentsView manageAssessmentsView = new ManageAssessmentsView();
+        Rectangle2D screenBounds = Screen.getPrimary().getVisualBounds();
+
+        manageAssessmentsStage = new Stage();
+        manageAssessmentsStage.setX(screenBounds.getMinX());
+        manageAssessmentsStage.setY(screenBounds.getMinY());
+        manageAssessmentsStage.setWidth(screenBounds.getWidth());
+        manageAssessmentsStage.setHeight(screenBounds.getHeight());
+        manageAssessmentsStage.setTitle("SMS - Manage Assessments");
+        manageAssessmentsStage.setScene(new Scene(manageAssessmentsView));
     }
 }

--- a/app/src/main/resources/styles/common.css
+++ b/app/src/main/resources/styles/common.css
@@ -38,6 +38,7 @@
 }
 
 /* User Interactive Components */
+/* Base button style */
 .button {
     -fx-background-color: #0a8edade;
     -fx-text-fill: white;
@@ -51,6 +52,30 @@
 
 .button:hover {
     -fx-background-color: derive(#0a8edade, -10%);
+}
+
+/* DatePicker button reset */
+.date-picker > .arrow-button {
+    -fx-background-color: transparent;
+    -fx-background-radius: 0;
+    -fx-padding: 4 8;
+    -fx-min-width: 0;
+}
+
+.date-picker > .arrow-button:hover {
+    -fx-background-color: -fx-cell-hover-color;
+}
+
+.date-picker-popup .button {
+    -fx-background-color: transparent;
+    -fx-background-radius: 0;
+    -fx-padding: 4 8;
+    -fx-min-width: 0;
+    -fx-pref-width: 0;
+}
+
+.date-picker-popup .button:hover {
+    -fx-background-color: -fx-cell-hover-color;
 }
 
 .text-field,

--- a/app/src/main/resources/styles/manager.css
+++ b/app/src/main/resources/styles/manager.css
@@ -3,7 +3,8 @@
 @import "common.css";
 
 .manage-student-view,
-.manage-course-view {
+.manage-course-view,
+.manage-assessments-view {
     -fx-background-color: white;
     -fx-padding: 10px;
 }
@@ -32,22 +33,12 @@
 }
 
 .action-button {
-    -fx-background-color: #0879bade;
-    -fx-background-radius: 5;
-    -fx-text-fill: white;
-    -fx-padding: 8px 15px;
+    /* Inherits most styles from .button */
     -fx-min-width: 100px;
-}
-
-.action-button:hover {
-    -fx-background-color: derive(#0879bade, -10%);
 }
 
 .navigate-button {
     -fx-background-color: #5c6469;
-    -fx-background-radius: 5px;
-    -fx-text-fill: white;
-    -fx-padding: 8px 15px;
     -fx-min-width: 100px;
 }
 


### PR DESCRIPTION
# Summary

## Problem

We are yet to implement the Manage Assessments functionality

## Solution

- Added `ManageAssessmentsView` to setup the layout of the page
- Added `ManageAssessmentsController` to handle interactions between view elements and CRUD operations with the database
- Made some tweaks to the CSS styles
  - The styles to `.button` were being applied globally. This meant that the buttons in the `DatePicker`'s were huge and bright blue. I added some code which applies out new button styles to all buttons except for DatePicker buttons. This can be adapted as needed for any other form elements which use buttons.

### Ready for merging?

No - need to discuss offline with the group about some decisions I made.

## Related Tickets
- https://github.com/AndGitRepos/StudentManagerSystem/issues/91
- https://github.com/AndGitRepos/StudentManagerSystem/issues/101

# Revisions

## Revision 1

Initial revision.

# Testing

`./gradlew build` Unit tests pass

# Pictures

<img width="1624" alt="Screenshot 2025-04-25 at 1 30 52 pm" src="https://github.com/user-attachments/assets/7f8dbe85-ebb1-40e0-a039-bd62333e3196" />

